### PR TITLE
Disable cutoff for Tfidf embedder

### DIFF
--- a/util/embedders.py
+++ b/util/embedders.py
@@ -37,7 +37,7 @@ def get_embedder(
             elif model == "bag-of-words":
                 embedder = BagOfWordsSentenceEmbedder(batch_size=batch_size)
             elif model == "tf-idf":
-                embedder = TfidfSentenceEmbedder(batch_size=batch_size)
+                embedder = TfidfSentenceEmbedder(batch_size=batch_size, min_df=0)
             else:
                 raise Exception(f"Unknown model {model}")
         elif (


### PR DESCRIPTION
Until now, we used a hardcoded cutoff value for the tfidf algorithm. This was set to 0.1, so only terms present in 10% of the documents would be used for building the vocabulary. With shorter texts or strongly different texts, this leads to very short embeddings (e.g. 6 for the clickbait project).
In this PR, I set the threshold to zero, so that all terms are present in the vocabulary. As we are using a PCA afterward the dimensionality is reduced. The features space should thereby be reduced to the most informative features (so that we don't necessarily need a cutoff).
But performance needs to be validated, while using.