### PR TITLE
tf-idf embeddings for search

### DIFF
--- a/util/embedders.py
+++ b/util/embedders.py
@@ -37,7 +37,7 @@ def get_embedder(
             elif model == "bag-of-words":
                 embedder = BagOfWordsSentenceEmbedder(batch_size=batch_size)
             elif model == "tf-idf":
-                embedder = TfidfSentenceEmbedder(batch_size=batch_size, min_df=0)
+                return TfidfSentenceEmbedder(batch_size=batch_size, min_df=0)
             else:
                 raise Exception(f"Unknown model {model}")
         elif (
@@ -65,9 +65,7 @@ def get_embedder(
         else:
             raise Exception(f"Unknown platform {platform}")
 
-        if (
-            platform == enums.EmbeddingPlatform.PYTHON.value and model == "tf-idf"
-        ) or record.count(project_id) < n_components:
+        if record.count(project_id) < n_components:
             # no PCA for tf-idf
             return embedder
         else:

--- a/util/embedders.py
+++ b/util/embedders.py
@@ -37,7 +37,7 @@ def get_embedder(
             elif model == "bag-of-words":
                 embedder = BagOfWordsSentenceEmbedder(batch_size=batch_size)
             elif model == "tf-idf":
-                embedder = TfidfSentenceEmbedder(batch_size=batch_size)
+                embedder = TfidfSentenceEmbedder(batch_size=batch_size, min_df=0)
             else:
                 raise Exception(f"Unknown model {model}")
         elif (
@@ -65,7 +65,10 @@ def get_embedder(
         else:
             raise Exception(f"Unknown platform {platform}")
 
-        if record.count(project_id) < n_components:
+        if (
+            platform == enums.EmbeddingPlatform.PYTHON.value and model == "tf-idf"
+        ) or record.count(project_id) < n_components:
+            # no PCA for tf-idf
             return embedder
         else:
             return PCASentenceReducer(embedder, n_components=n_components)


### PR DESCRIPTION

PRs:
- https://github.com/code-kern-ai/refinery-embedder/pull/89
- https://github.com/code-kern-ai/refinery-submodule-model/pull/91
- https://github.com/code-kern-ai/refinery-neural-search/pull/55
- https://github.com/code-kern-ai/refinery-updater/pull/64


Enables tf-idf for search by:
1. fixing min_df to 0
2. removing PCA
3. using cosine dist for similarity search

The submodule PR also holds a hotfix for the empty integer fields for embedding creations by only casting the running_id to int.
