### PR TITLE
ci(pi): kernai/refinery-parent-images:v2.2.0-torch-cpu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.1.0-torch-cpu
+FROM kernai/refinery-parent-images:v2.2.0-torch-cpu
 
 WORKDIR /program
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.1.0-torch-cpu
+FROM kernai/refinery-parent-images:v2.2.0-torch-cpu
 
 WORKDIR /app
 

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.1.0-torch-cuda
+FROM kernai/refinery-parent-images:v2.2.0-torch-cuda
 
 WORKDIR /program
 


### PR DESCRIPTION
Automated parent image release for:
- https://github.com/code-kern-ai/refinery-torch-cpu-parent-image/releases/tag/v2.2.0