### PR TITLE
opengrep: apply agent fixes

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -18,7 +18,7 @@ from openai import APIConnectionError
 
 from src.embedders import Transformer, util
 
-# Embedder imports are used by eval(Embedder) in __setup_tmp_embedder
+# Embedder classes are resolved by get_embedder_class() when loading serialized configs
 from src.embedders.classification.contextual import (  # noqa: F401
     OpenAISentenceEmbedder,
     HuggingFaceSentenceEmbedder,
@@ -29,6 +29,7 @@ from src.util import request_util
 from src.util.decorator import param_throttle
 from src.util.embedders import get_embedder
 from src.util.notification import send_project_update, embedding_warning_templates
+from src.util.safe_embedder_cls import get_embedder_class
 
 from submodules.s3 import controller as s3
 from submodules.model import enums, daemon
@@ -658,7 +659,7 @@ def __setup_tmp_embedder(project_id: str, embedder_id: str) -> Transformer:
 def __load_embedder_by_path(embedder_path: str) -> Transformer:
     with open(embedder_path, "r") as f:
         embedder = json.load(f)
-        Embedder = eval(embedder["cls"])
+        Embedder = get_embedder_class(embedder["cls"])
         return Embedder.load(embedder)
 
 

--- a/src/embedders/classification/reduce.py
+++ b/src/embedders/classification/reduce.py
@@ -3,13 +3,7 @@ from typing import Union, List, Generator
 import numpy as np
 import pickle
 from src.embedders import PCAReducer, util
-
-# Embedder imports are used by eval(Embedder) in load methods
-from src.embedders.classification.contextual import (  # noqa: F401
-    OpenAISentenceEmbedder,
-    HuggingFaceSentenceEmbedder,
-    PrivatemodeAISentenceEmbedder,
-)
+from src.util.safe_embedder_cls import get_embedder_class
 
 
 class PCASentenceReducer(PCAReducer):
@@ -73,7 +67,7 @@ class PCASentenceReducer(PCAReducer):
         reducer = pickle.loads(
             embedder["reducer_pkl_bytes"].encode("latin-1")
         )  # Decode to latin1 to avoid binary issues in JSON
-        Embedder = eval(embedder["embedder"]["cls"])
+        Embedder = get_embedder_class(embedder["embedder"]["cls"])
         return PCASentenceReducer(
             embedder=Embedder.load(embedder["embedder"]),
             reducer=reducer,

--- a/src/util/safe_embedder_cls.py
+++ b/src/util/safe_embedder_cls.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Resolve embedder class names to classes without using eval().
+Used when loading serialized embedder configs (e.g. from JSON).
+"""
+
+from typing import Any, Type
+
+_ALLOWED_EMBEDDER_CLASSES = frozenset({
+    "HuggingFaceSentenceEmbedder",
+    "OpenAISentenceEmbedder",
+    "PrivatemodeAISentenceEmbedder",
+    "PCASentenceReducer",
+})
+
+
+def get_embedder_class(name: str) -> Type[Any]:
+    """
+    Return the embedder class for the given name.
+    Only allows known embedder class names to prevent code injection.
+    """
+    if name not in _ALLOWED_EMBEDDER_CLASSES:
+        raise ValueError(f"Unknown embedder class: {name!r}")
+    if name == "PCASentenceReducer":
+        from src.embedders.classification.reduce import PCASentenceReducer
+        return PCASentenceReducer
+    if name == "HuggingFaceSentenceEmbedder":
+        from src.embedders.classification.contextual import HuggingFaceSentenceEmbedder
+        return HuggingFaceSentenceEmbedder
+    if name == "OpenAISentenceEmbedder":
+        from src.embedders.classification.contextual import OpenAISentenceEmbedder
+        return OpenAISentenceEmbedder
+    if name == "PrivatemodeAISentenceEmbedder":
+        from src.embedders.classification.contextual import PrivatemodeAISentenceEmbedder
+        return PrivatemodeAISentenceEmbedder
+    raise ValueError(f"Unknown embedder class: {name!r}")


### PR DESCRIPTION
Automated opengrep resolution: static-analysis findings fixed by Cursor Agent. Please review the changes and verify correctness.

### Included changes
- `controller.py:661` — **python.lang.security.audit.eval-detected.eval-detected** (WARNING)
- `src/embedders/classification/reduce.py:76` — **python.lang.security.audit.eval-detected.eval-detected** (WARNING)

**Main PR:** https://github.com/code-kern-ai/cognition-ui/pull/205