### PR TITLE
ci(pi): kernai/refinery-parent-images:v3.0.0-torch-cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.6.0-torch-cpu
+FROM kernai/refinery-parent-images:v3.0.0-torch-cpu
 
 WORKDIR /program
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.6.0-torch-cpu
+FROM kernai/refinery-parent-images:v3.0.0-torch-cpu
 
 WORKDIR /app
 

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v2.6.0-torch-cuda
+FROM kernai/refinery-parent-images:v3.0.0-torch-cuda
 
 WORKDIR /program
 


### PR DESCRIPTION
Automated parent image release for:
- https://github.com/code-kern-ai/refinery-torch-cuda-parent-image/releases/tag/v3.0.0